### PR TITLE
Include installed client list in "client-list" message

### DIFF
--- a/src/local-messaging.js
+++ b/src/local-messaging.js
@@ -141,7 +141,7 @@ function start() {
 function configureInstalledList() {
   const manifest = commonConfig.getManifest();
 
-  installedClients = Object.keys(manifest).length > 0 ? Object.keys(manifest) : [];
+  installedClients = Object.keys(manifest);
 }
 
 module.exports = {

--- a/src/local-messaging.js
+++ b/src/local-messaging.js
@@ -76,19 +76,31 @@ function initIPC() {
       if (data && data.client) {
         clients.add(data.client);
 
+        const message = {topic: "client-list", installedClients, clients: Array.from(clients), status: "connected", client: data.client};
+
         ipc.server.broadcast(
           "message",
-          {topic: "client-list", installedClients, clients: Array.from(clients), status: "connected", client: data.client}
+          message
         );
+
+        if (spark) {
+          spark.write(message);
+        }
       }
     });
 
     ipc.server.on("clientlist-request", (data, socket) => {
+      const message = {topic: "client-list", installedClients, clients: Array.from(clients)};
+
       ipc.server.emit(
         socket,
         "message",
-        {topic: "client-list", installedClients, clients: Array.from(clients)}
+        message
       );
+
+      if (spark) {
+        spark.write(message);
+      }
     });
 
     ipc.server.on("socket.disconnected", (socket, destroyedSocketID) => {
@@ -97,10 +109,16 @@ function initIPC() {
 
       clients.delete(destroyedSocketID);
 
+      const message = {topic: "client-list", clients: Array.from(clients), status: "disconnected", client: destroyedSocketID};
+
       ipc.server.broadcast(
         "message",
-        {topic: "client-list", clients: Array.from(clients), status: "disconnected", client: destroyedSocketID}
+        message
       );
+
+      if (spark) {
+        spark.write(message);
+      }
     });
 
   });


### PR DESCRIPTION
- Installed client list will be used by Image/Video widgets to know if RLS is expected and therefore know to work with RLS instead of RC
- "client-list" message now broadcast to local WS client (browser)