### PR TITLE
add details to log external

### DIFF
--- a/src/external-logger.js
+++ b/src/external-logger.js
@@ -4,17 +4,13 @@ const localMessaging = require("./local-messaging");
 
 let displaySettings = {};
 
-function validateMessage(message, detail) {
+function validateMessage(message) {
   let error = "";
 
   if (!message) {
     error = "Message is required";
   } else if (!message.data.data.event) {
     error = "BQ event is required";
-  } else if (!Object.keys(detail).length) {
-    /* Checks detail separately since its value combined
-    with another object that specifies the event */
-    error = "BQ detail is required";
   }
 
   return error;
@@ -48,7 +44,7 @@ function constructMessage(evt, detail, table, moduleName) {
 module.exports = {
     log(evt, detail, table, moduleName) {
       const message = constructMessage(evt, detail, table, moduleName);
-      const messageError = validateMessage(message, detail);
+      const messageError = validateMessage(message);
 
       if (!messageError) {
         if (localMessaging.isInClientList("logging")) {

--- a/src/local-messaging.js
+++ b/src/local-messaging.js
@@ -65,10 +65,7 @@ function initPrimus(displayId, machineId) {
 
   return new Promise(res=>ms.on("open", ()=>{
     log.file(null, "MS connection opened");
-    setTimeout(()=>log.external("MS connection opened", {
-      "event_details": "",
-      "version": config.getModuleVersion()
-    }), loggerModuleDelay);
+    setTimeout(()=>log.external("MS connection opened"), loggerModuleDelay);
     res();
   }));
 }

--- a/src/local-messaging.js
+++ b/src/local-messaging.js
@@ -65,7 +65,10 @@ function initPrimus(displayId, machineId) {
 
   return new Promise(res=>ms.on("open", ()=>{
     log.file(null, "MS connection opened");
-    setTimeout(()=>log.external("MS connection opened"), loggerModuleDelay);
+    setTimeout(()=>log.external("MS connection opened", {
+      "event_details": "",
+      "version": config.getModuleVersion()
+    }), loggerModuleDelay);
     res();
   }));
 }

--- a/test/integration/external-logger.js
+++ b/test/integration/external-logger.js
@@ -32,11 +32,6 @@ describe("Logging Events : Integration", ()=>{
       console.log(log.file.lastCall.args[0]);
       assert.deepEqual(log.file.lastCall.args[0], "external-logger error: BQ event is required");
     });
-
-    it("should not send message to LM and log error if message.data.detail is null", ()=>{
-      externalLogger.log("test-event", {});
-      assert.deepEqual(log.file.lastCall.args[0], "external-logger error: BQ detail is required");
-    });
   });
 
    describe("External Logging", ()=>{


### PR DESCRIPTION
Not passing detail structure is causing local messaging to crash here: 

https://github.com/Rise-Vision/local-messaging-module/blob/master/src/external-logger.js#L14

As Object.keys(detail) on an undefined reference fails.

Which in turn causes all inter-module messaging to stop working after a few seconds, and no data being logged to BQ.
