### PR TITLE
Add SIGPIPE handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ function dump(err) {
 
 global.log = require("rise-common-electron").logger(preventBQLog ? null : externalLogger, modulePath, config.moduleName);
 
+process.on("SIGPIPE", () => log.external("SIGPIPE received"));
+
 ipc.config.id = "lms";
 ipc.config.retry = 1500;
 


### PR DESCRIPTION
## Description

Avoid process being killed when it receives a SIGPIPE. Pipe signal is not handled by default when the process is started as shared library (which is the case when run by electron)

## Motivation and Context
Why is this change required? What problem does it solve?

This is an attempt to fix https://github.com/Rise-Vision/rise-launcher-electron/issues/827 . We couldn't reproduce the issue, but when local messaging module is killed the display logs the same error messages as displays that reported issue 827.

## How Has This Been Tested?
Tested manually with the staged package

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
